### PR TITLE
Fix stale commit link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npx snarkjs@0.6.11 powersoftau verify powersOfTau28_hez_final_21.ptau -v
 
 # Reproducing the .r1cs file
 
-To reproduce `main.r1cs`, clone the [Aptos Keyless Circuit Repo](https://github.com/aptos-labs/aptos-keyless-circuit/tree/legacy), checkout commit `tbd`, and run the following commands:
+To reproduce `main.r1cs`, clone the [Aptos Keyless circuit repo](https://github.com/aptos-labs/aptos-keyless-circuit/tree/legacy), checkout commit [`8c6d2674906b868e27a9dc010e71b1847e9987a6`](https://github.com/aptos-labs/aptos-keyless-circuit/tree/8c6d2674906b868e27a9dc010e71b1847e9987a6), and run the following commands:
 
 ```
 cd templates/

--- a/README.md
+++ b/README.md
@@ -63,8 +63,11 @@ npx snarkjs@0.6.11 powersoftau verify powersOfTau28_hez_final_21.ptau -v
 To reproduce `main.r1cs`, clone the [Aptos Keyless circuit repo](https://github.com/aptos-labs/aptos-keyless-circuit/tree/legacy), checkout commit [`8c6d2674906b868e27a9dc010e71b1847e9987a6`](https://github.com/aptos-labs/aptos-keyless-circuit/tree/8c6d2674906b868e27a9dc010e71b1847e9987a6), and run the following commands:
 
 ```
+git clone https://github.com/aptos-labs/aptos-keyless-circuit/
+git checkout 8c6d2674906b868e27a9dc010e71b1847e9987a6
 cd templates/
 circom -l . main.circom --r1cs
+b2sum main.r1cs
 ```
 
 The `b2sum` hash of the resulting `main.r1cs` file should be 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ npx snarkjs@0.6.11 powersoftau verify powersOfTau28_hez_final_21.ptau -v
 
 # Reproducing the .r1cs file
 
-To reproduce `main.r1cs`, clone the [Aptos Keyless Circuit Repo](https://github.com/aptos-labs/aptos-keyless-circuit), checkout commit `2a1d445a49d212fa55c322e6f3373631bc74140a`, and run the following commands:
+To reproduce `main.r1cs`, clone the [Aptos Keyless Circuit Repo](https://github.com/aptos-labs/aptos-keyless-circuit/tree/legacy), checkout commit `tbd`, and run the following commands:
 
 ```
-cd templates
+cd templates/
 circom -l . main.circom --r1cs
 ```
 


### PR DESCRIPTION
The instructions for reproducing the R1CS give a link to the old [`aptos-keyless-circuit` repo](https://github.com/aptos-labs/aptos-keyless-circuit), whose commit history has been purged.

As a result, the old commit cannot be found anymore.

This PR points to a new `legacy` branch in the [`aptos-keyless-circuit` repo](https://github.com/aptos-labs/aptos-keyless-circuit/tree/legacy) and makes everything re-verifiable again.